### PR TITLE
fix: fix telemetry connection string retrieval method

### DIFF
--- a/src/00-hello-world/agent.py
+++ b/src/00-hello-world/agent.py
@@ -41,7 +41,7 @@ project_client = AIProjectClient(
     )
 
 from azure.monitor.opentelemetry import configure_azure_monitor
-connection_string = project_client.telemetry.get_application_insights_connection_string()
+connection_string = project_client.telemetry.get_connection_string()
 
 if not connection_string:
     print("Application Insights is not enabled. Enable by going to Tracing in your Azure AI Foundry project.")

--- a/src/01-agents-rag/agent-execution.py
+++ b/src/01-agents-rag/agent-execution.py
@@ -30,7 +30,7 @@ project_client = AIProjectClient(
     )
 
 from azure.monitor.opentelemetry import configure_azure_monitor
-connection_string = project_client.telemetry.get_application_insights_connection_string()
+connection_string = project_client.telemetry.get_connection_string()
 
 configure_azure_monitor(connection_string=connection_string) #enable telemetry collection
 

--- a/src/01-agents-rag/agent-search.py
+++ b/src/01-agents-rag/agent-search.py
@@ -31,7 +31,7 @@ project_client = AIProjectClient(
     )
 
 from azure.monitor.opentelemetry import configure_azure_monitor
-connection_string = project_client.telemetry.get_application_insights_connection_string()
+connection_string = project_client.telemetry.get_connection_string()
 
 configure_azure_monitor(connection_string=connection_string) #enable telemetry collection
 

--- a/src/01-agents-rag/agent-tools.py
+++ b/src/01-agents-rag/agent-tools.py
@@ -31,7 +31,7 @@ project_client = AIProjectClient(
     )
 
 from azure.monitor.opentelemetry import configure_azure_monitor
-connection_string = project_client.telemetry.get_application_insights_connection_string()
+connection_string = project_client.telemetry.get_connection_string()
 
 configure_azure_monitor(connection_string=connection_string) #enable telemetry collection
 

--- a/src/02-react-agents/simple-react.py
+++ b/src/02-react-agents/simple-react.py
@@ -56,7 +56,7 @@ project_client = AIProjectClient(
         endpoint=os.environ["PROJECT_ENDPOINT"],
     )
 
-connection_string = project_client.telemetry.get_application_insights_connection_string()
+connection_string = project_client.telemetry.get_connection_string()
 
 @tool
 def get_current_username(input: str) -> str:


### PR DESCRIPTION
This pull request fixes the way telemetry connection strings are retrieved across several agent scripts.
The main change is replacing the call to `get_application_insights_connection_string()` with `get_connection_string()`
Telemetry configuration updates:

* Replaced `project_client.telemetry.get_application_insights_connection_string()` with `project_client.telemetry.get_connection_string()` in the following files to standardize how telemetry connection strings are fetched:
  * `src/00-hello-world/agent.py`
  * `src/01-agents-rag/agent-execution.py`
  * `src/01-agents-rag/agent-search.py`
  * `src/01-agents-rag/agent-tools.py`
  * `src/02-react-agents/simple-react.py`