### PR TITLE
fix: update connection string retrieval for application insights

### DIFF
--- a/src/01-agents-rag/agent-bing.py
+++ b/src/01-agents-rag/agent-bing.py
@@ -32,7 +32,7 @@ project_client = AIProjectClient(
     )
 
 from azure.monitor.opentelemetry import configure_azure_monitor
-connection_string = project_client.telemetry.get_connection_string()
+connection_string = project_client.telemetry.get_application_insights_connection_string()
 
 configure_azure_monitor(connection_string=connection_string) #enable telemetry collection
 


### PR DESCRIPTION
This pull request updates the telemetry configuration in the `src/01-agents-rag/agent-bing.py` file to use the correct method for retrieving the Application Insights connection string.

Telemetry configuration update:

* Changed the method call from `get_connection_string()` to `get_application_insights_connection_string()` to ensure the correct connection string is used for Azure Monitor telemetry.